### PR TITLE
Expose country picker styling methods to style its sub views

### DIFF
--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -141,7 +141,7 @@ extension CountryCell {
     ///
     /// - Parameter style: Flag style kind
     
-    func styleFlagView(_ style: CountryFlagStyle) {
+    func applyFlagStyle(_ style: CountryFlagStyle) {
         
         // Cleae all constraints from flag image view
         NSLayoutConstraint.deactivate(flagImageView.constraints)
@@ -149,7 +149,7 @@ extension CountryCell {
         
         switch style {
         case .corner:
-            // Corner style 
+            // Corner style
             flagImageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
             flagImageView.heightAnchor.constraint(equalToConstant: 26).isActive = true
             flagImageView.layer.cornerRadius = 4

--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -22,6 +22,10 @@ class CountryCell: UITableViewCell {
         return imageView
     }()
 
+    var flagStyle: CountryFlagStyle {
+        return CountryFlagStyle.normal
+    }
+    
     let nameLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -128,6 +132,42 @@ extension CountryCell {
         separatorLineView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
         separatorLineView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
         separatorLineView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
+    }
+    
+    
+    /// Apply some styling on flag image view
+    ///
+    /// - Note: By default, `CountryFlagStyle.nromal` style is applied on the flag image view.
+    ///
+    /// - Parameter style: Flag style kind
+    
+    func styleFlagView(_ style: CountryFlagStyle) {
+        
+        // Cleae all constraints from flag image view
+        NSLayoutConstraint.deactivate(flagImageView.constraints)
+        layoutIfNeeded()
+        
+        switch style {
+        case .corner:
+            // Corner style 
+            flagImageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
+            flagImageView.heightAnchor.constraint(equalToConstant: 26).isActive = true
+            flagImageView.layer.cornerRadius = 4
+            flagImageView.clipsToBounds = true
+            flagImageView.contentMode = .scaleAspectFill
+        case .circular:
+            // Circular style
+            flagImageView.widthAnchor.constraint(equalToConstant: 34).isActive = true
+            flagImageView.heightAnchor.constraint(equalToConstant: 34).isActive = true
+            flagImageView.layer.cornerRadius = 34 / 2
+            flagImageView.clipsToBounds = true
+            flagImageView.contentMode = .scaleAspectFill
+        default:
+            // Apply default styling
+            flagImageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
+            flagImageView.heightAnchor.constraint(equalToConstant: 26).isActive = true
+            flagImageView.contentMode = .scaleToFill
+        }
     }
     
     

--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -114,13 +114,13 @@ extension CountryCell {
         if #available(iOS 11.0, *) {
             countryContentStackView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 15).isActive = true
             countryContentStackView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -30).isActive = true
-            countryContentStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
-            countryContentStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -8).isActive = true
+            countryContentStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 4).isActive = true
+            countryContentStackView.bottomAnchor.constraint(equalTo: separatorLineView.topAnchor, constant: -4).isActive = true
         } else {
             countryContentStackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 15).isActive = true
             countryContentStackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -30).isActive = true
-            countryContentStackView.topAnchor.constraint(equalTo: topAnchor, constant: 8).isActive = true
-            countryContentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8).isActive = true
+            countryContentStackView.topAnchor.constraint(equalTo: topAnchor, constant: 4).isActive = true
+            countryContentStackView.bottomAnchor.constraint(equalTo: separatorLineView.topAnchor, constant: -4).isActive = true
         }
         
         // Configure constraints on separator view

--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -44,6 +44,7 @@ class CountryCell: UITableViewCell {
 
     let flagImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.contentMode = UIView.ContentMode.scaleToFill
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
         imageView.heightAnchor.constraint(equalToConstant: 26).isActive = true

--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -128,5 +128,22 @@ extension CountryCell {
         separatorLineView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
         separatorLineView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
     }
+    
+    
+    /// Hides dialing code label
+    ///
+    /// - Parameter state: Visibility boolean state. By default it's set to `True`
+    func hideDialCode(_ state: Bool = true) {
+        diallingCodeLabel.isHidden = state
+    }
+    
+    
+    /// Hides country flag view
+    ///
+    /// - Parameter state: Visibility boolean state. By default it's set to `True`
+    func hideFlag(_ state: Bool = true) {
+        countryFlagStackView.isHidden = state
+    }
+    
 }
 

--- a/CountryPicker/CountryPicker/CountryCell.swift
+++ b/CountryPicker/CountryPicker/CountryCell.swift
@@ -14,16 +14,18 @@ class CountryCell: UITableViewCell {
     static let reuseIdentifier = String(describing: CountryCell.self)
 
     let checkMarkImageView: UIImageView = {
-       let imageView = UIImageView()
-       imageView.translatesAutoresizingMaskIntoConstraints = false
-       imageView.contentMode = .scaleAspectFit
-       return imageView
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.widthAnchor.constraint(equalToConstant: 20).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 25).isActive = true
+        return imageView
     }()
 
     let nameLabel: UILabel = {
-       let label = UILabel()
-       label.translatesAutoresizingMaskIntoConstraints = false
-       return label
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
     }()
 
     let diallingCodeLabel: UILabel = {
@@ -33,18 +35,46 @@ class CountryCell: UITableViewCell {
     }()
 
     let separatorLineView: UIView = {
-       let view = UIView()
-       view.backgroundColor = UIColor.gray
-       view.translatesAutoresizingMaskIntoConstraints = false
-       return view
+        let view = UIView()
+        view.backgroundColor = UIColor.gray
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        return view
     }()
 
     let flagImageView: UIImageView = {
-       let imageView = UIImageView()
-       imageView.translatesAutoresizingMaskIntoConstraints = false
-       return imageView
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 26).isActive = true
+        return imageView
     }()
 
+    
+    // MARK: - Private properties
+    private var countryContentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 15
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    private var countryInfoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.spacing = 5
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    
+    private var countryFlagStackView: UIStackView = UIStackView()
+    private var countryCheckStackView: UIStackView = UIStackView()
+    
+    
     // MARK: - Model
     var country: Country! {
         didSet {
@@ -56,59 +86,47 @@ class CountryCell: UITableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        setUpView()
+        setupViews()
     }
+}
 
-    // MARK: - View SetUp
-    private func setUpView() {
-        setUpFlagImageView()
-        setUpLabels()
-        setUpSepratorView()
-        setUpCheckMarkImageView()
-    }
-
-    private func setUpFlagImageView() {
-        addSubview(flagImageView)
+extension CountryCell {
+    
+    func setupViews() {
+        
+        // Add country flag & check mark views
+        countryFlagStackView.addArrangedSubview(flagImageView)
+        countryCheckStackView.addArrangedSubview(checkMarkImageView)
+        
+        // Add country info sub views
+        countryInfoStackView.addArrangedSubview(nameLabel)
+        countryInfoStackView.addArrangedSubview(diallingCodeLabel)
+        
+        // Add stackviews into country content stack
+        countryContentStackView.addArrangedSubview(countryFlagStackView)
+        countryContentStackView.addArrangedSubview(countryInfoStackView)
+        countryContentStackView.addArrangedSubview(countryCheckStackView)
+        
+        addSubview(countryContentStackView)
+        addSubview(separatorLineView)
+        
+        // Configure constraints on country content stack 
         if #available(iOS 11.0, *) {
-            flagImageView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 8).isActive = true
-            flagImageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
+            countryContentStackView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor, constant: 15).isActive = true
+            countryContentStackView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -30).isActive = true
+            countryContentStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 8).isActive = true
+            countryContentStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -8).isActive = true
         } else {
-            flagImageView.leftAnchor.constraint(equalTo: leftAnchor, constant: 8).isActive = true
-            flagImageView.topAnchor.constraint(equalTo: topAnchor, constant: 8).isActive = true
+            countryContentStackView.leftAnchor.constraint(equalTo: leftAnchor, constant: 15).isActive = true
+            countryContentStackView.rightAnchor.constraint(equalTo: rightAnchor, constant: -30).isActive = true
+            countryContentStackView.topAnchor.constraint(equalTo: topAnchor, constant: 8).isActive = true
+            countryContentStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8).isActive = true
         }
         
-        flagImageView.widthAnchor.constraint(equalToConstant: 50).isActive = true
-        flagImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-    }
-
-    private func setUpLabels() {
-        addSubview(nameLabel)
-        addSubview(diallingCodeLabel)
-
-        nameLabel.topAnchor.constraint(equalTo: flagImageView.topAnchor).isActive = true
-        nameLabel.leftAnchor.constraint(equalTo: flagImageView.rightAnchor, constant: 8).isActive = true
-
-        diallingCodeLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 8).isActive = true
-        diallingCodeLabel.leftAnchor.constraint(equalTo: nameLabel.leftAnchor).isActive = true
-    }
-
-    private func setUpSepratorView() {
-        addSubview(separatorLineView)
-
+        // Configure constraints on separator view
         separatorLineView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
-        separatorLineView.heightAnchor.constraint(equalToConstant: 1).isActive = true
-        separatorLineView.leftAnchor.constraint(equalTo: diallingCodeLabel.leftAnchor).isActive = true
         separatorLineView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
-
+        separatorLineView.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
     }
-
-    private func setUpCheckMarkImageView() {
-        addSubview(checkMarkImageView)
-
-        checkMarkImageView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
-        checkMarkImageView.widthAnchor.constraint(equalToConstant: 25).isActive = true
-        checkMarkImageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        checkMarkImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20).isActive = true
-    }
-
 }
+

--- a/CountryPicker/CountryPicker/CountryManager.swift
+++ b/CountryPicker/CountryPicker/CountryManager.swift
@@ -9,6 +9,20 @@
 import Foundation
 import UIKit
 
+
+/// Country filtering options
+public enum CountryFilterOption {
+    /// Filter countries by country name
+    case countryName
+    
+    /// Filter countries by country code
+    case countryCode
+    
+    /// Filter countries by country dial code
+    case countryDialCode
+}
+
+
 open class CountryManager {
     
     // MARK: - variable

--- a/CountryPicker/CountryPicker/CountryManager.swift
+++ b/CountryPicker/CountryPicker/CountryManager.swift
@@ -9,19 +9,6 @@
 import Foundation
 import UIKit
 
-
-/// Country filtering options
-public enum CountryFilterOption {
-    /// Filter countries by country name
-    case countryName
-    
-    /// Filter countries by country code
-    case countryCode
-    
-    /// Filter countries by country dial code
-    case countryDialCode
-}
-
 open class CountryManager {
     
     // MARK: - variable

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -37,6 +37,10 @@ open class CountryPickerController: UIViewController {
     public var statusBarStyle: UIStatusBarStyle? = .default
     public var isStatusBarVisible = true
     
+    public var flagStyle: CountryFlagStyle = CountryFlagStyle.normal {
+        didSet { self.tableView.reloadData() }
+    }
+    
     public var labelFont: UIFont = UIFont.systemFont(ofSize: 14.0) {
         didSet { self.tableView.reloadData() }
     }
@@ -259,6 +263,7 @@ extension CountryPickerController: UITableViewDelegate, UITableViewDataSource {
         cell.diallingCodeLabel.font = detailFont
         cell.diallingCodeLabel.textColor = detailColor
         cell.separatorLineView.backgroundColor = self.separatorLineColor
+        cell.styleFlagView(flagStyle)
     }
     
     // MARK: - TableView Delegate

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -247,12 +247,15 @@ extension CountryPickerController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func setUpCellProperties(cell: CountryCell) {
-        cell.nameLabel.font = self.labelFont
-        cell.nameLabel.textColor = self.labelColor
-        cell.diallingCodeLabel.font = self.detailFont
-        cell.diallingCodeLabel.textColor = self.detailColor
-        cell.flagImageView.isHidden = self.isHideFlagImage
-        cell.diallingCodeLabel.isHidden = self.isHideDiallingCode
+        
+        // Auto-hide flag & dial labels
+        cell.hideFlag(isHideFlagImage)
+        cell.hideDialCode(isHideDiallingCode)
+        
+        cell.nameLabel.font = labelFont
+        cell.nameLabel.textColor = labelColor
+        cell.diallingCodeLabel.font = detailFont
+        cell.diallingCodeLabel.textColor = detailColor
         cell.separatorLineView.backgroundColor = self.separatorLineColor
     }
     

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -41,7 +41,7 @@ open class CountryPickerController: UIViewController {
         didSet { self.tableView.reloadData() }
     }
     
-    public var labelFont: UIFont = UIFont.systemFont(ofSize: 14.0) {
+    public var labelFont: UIFont = UIFont.systemFont(ofSize: 15.0) {
         didSet { self.tableView.reloadData() }
     }
     
@@ -49,7 +49,7 @@ open class CountryPickerController: UIViewController {
         didSet { self.tableView.reloadData() }
     }
     
-    public var detailFont: UIFont = UIFont.systemFont(ofSize: 11.0) {
+    public var detailFont: UIFont = UIFont.systemFont(ofSize: 12.0) {
         didSet { self.tableView.reloadData() }
     }
     
@@ -105,8 +105,6 @@ open class CountryPickerController: UIViewController {
         let nib = UINib(nibName: "CountryTableViewCell", bundle: bundle)
         tableView.register(nib, forCellReuseIdentifier: "CountryTableViewCell")
         tableView.register(CountryCell.self, forCellReuseIdentifier: CountryCell.reuseIdentifier)
-        tableView.estimatedRowHeight = 70.0
-        tableView.rowHeight = UITableView.automaticDimension
         
         // Setup search controller view
         setUpsSearchController()
@@ -147,7 +145,8 @@ open class CountryPickerController: UIViewController {
         tableView.dataSource = self
         tableView.separatorStyle = .none
         tableView.contentInset = UIEdgeInsets.zero
-        tableView.estimatedRowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 70.0
+        tableView.rowHeight = UITableView.automaticDimension
         
         if #available(iOS 11.0, *) {
             NSLayoutConstraint.activate([
@@ -283,7 +282,7 @@ extension CountryPickerController: UITableViewDelegate, UITableViewDataSource {
     }
     
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 50.0
+        return 60.0
     }
     
 }

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -53,7 +53,7 @@ open class CountryPickerController: UIViewController {
         didSet { self.tableView.reloadData() }
     }
     
-    public var separatorLineColor: UIColor = UIColor.lightGray {
+    public var separatorLineColor: UIColor = UIColor(red: 249/255.0, green: 248/255.0, blue: 252/255.0, alpha: 1.0) {
         didSet { self.tableView.reloadData() }
     }
     

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -101,6 +101,8 @@ open class CountryPickerController: UIViewController {
         let nib = UINib(nibName: "CountryTableViewCell", bundle: bundle)
         tableView.register(nib, forCellReuseIdentifier: "CountryTableViewCell")
         tableView.register(CountryCell.self, forCellReuseIdentifier: CountryCell.reuseIdentifier)
+        tableView.estimatedRowHeight = 70.0
+        tableView.rowHeight = UITableView.automaticDimension
         
         // Setup search controller view
         setUpsSearchController()

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -8,6 +8,21 @@
 
 import UIKit
 
+
+/// Country flag styles
+public enum CountryFlagStyle {
+    
+    // Corner style will be applied
+    case corner
+    
+    // Circular style will be applied
+    case circular
+    
+    // Rectangle style will be applied
+    case normal
+}
+
+
 open class CountryPickerController: UIViewController {
     
     // MARK: - Variables

--- a/CountryPicker/CountryPicker/CountryPickerController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerController.swift
@@ -263,7 +263,7 @@ extension CountryPickerController: UITableViewDelegate, UITableViewDataSource {
         cell.diallingCodeLabel.font = detailFont
         cell.diallingCodeLabel.textColor = detailColor
         cell.separatorLineView.backgroundColor = self.separatorLineColor
-        cell.styleFlagView(flagStyle)
+        cell.applyFlagStyle(flagStyle)
     }
     
     // MARK: - TableView Delegate

--- a/Enums.swift
+++ b/Enums.swift
@@ -1,0 +1,34 @@
+//
+//  Enums.swift
+//  SKCountryPicker
+//
+//  Created by Sharkes Monken on 17/08/2019.
+//
+
+import Foundation
+
+/// Country flag styles
+public enum CountryFlagStyle {
+    
+    // Corner style will be applied
+    case corner
+    
+    // Circular style will be applied
+    case circular
+    
+    // Rectangle style will be applied
+    case normal
+}
+
+
+/// Country filtering options
+public enum CountryFilterOption {
+    /// Filter countries by country name
+    case countryName
+    
+    /// Filter countries by country code
+    case countryCode
+    
+    /// Filter countries by country dial code
+    case countryDialCode
+}

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -209,7 +209,6 @@
 		5FE4034051CC758FFFDE9593D2E1ECDB /* GY@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 52FB174CF5628B15957E27C66D4A7A64 /* GY@2x.png */; };
 		6012CA2F31E60398C3B65505DB18911D /* UG.png in Resources */ = {isa = PBXBuildFile; fileRef = 30735D53BA3B69E985469DB5F75D43CD /* UG.png */; };
 		62B90EE76F9D6FCC4D820434746EACD5 /* KI@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 48B9189D002CEAE95706764F2FA907ED /* KI@2x.png */; };
-		631A9BEA2308450900962232 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A9BE92308450900962232 /* Enums.swift */; };
 		6343ED6F9516DBECB358FE16B110111B /* CountryPickerController.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 485DCD3FCE4332DD3B4869033850BB16 /* CountryPickerController.bundle */; };
 		64059E67429D1B88DC3DEE3063822B51 /* CZ.png in Resources */ = {isa = PBXBuildFile; fileRef = 816698E10B8863EA0DF3B2ABED1A8615 /* CZ.png */; };
 		64228C345052861ABAE393E9290EEFF4 /* IN.png in Resources */ = {isa = PBXBuildFile; fileRef = D69FD0E7D78D6A2CDD992DCC4B3CF8A3 /* IN.png */; };
@@ -748,7 +747,6 @@
 		62035424BD6BB698AD59E21DF082875C /* CD@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "CD@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/CD@2x.png"; sourceTree = "<group>"; };
 		628DB67DD5A892677E392AB0AB149B81 /* AO.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = AO.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/AO.png; sourceTree = "<group>"; };
 		62C8D67B33AAA6D350FB7D4F2B14039E /* KN.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = KN.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/KN.png; sourceTree = "<group>"; };
-		631A9BE92308450900962232 /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		64498467524F084AEF00CF649C73EADA /* BA.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = BA.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/BA.png; sourceTree = "<group>"; };
 		645DE9098F037565B92752A07039EE1A /* AI@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "AI@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/AI@2x.png"; sourceTree = "<group>"; };
 		64931DA9060A058A4381BB0F6F82CD44 /* WF.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = WF.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/WF.png; sourceTree = "<group>"; };
@@ -1641,14 +1639,6 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		631A9BE62308448200962232 /* Helper */ = {
-			isa = PBXGroup;
-			children = (
-				631A9BE92308450900962232 /* Enums.swift */,
-			);
-			name = Helper;
-			sourceTree = "<group>";
-		};
 		A0653EA217AF5FA3B39795A22A39C235 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1714,7 +1704,6 @@
 		D32A5D8D77B23CC2ECAD2EE7259AAD22 /* SKCountryPicker */ = {
 			isa = PBXGroup;
 			children = (
-				631A9BE62308448200962232 /* Helper */,
 				269A9A60ABDEFB7BDE22BE864428521C /* Constant.swift */,
 				403F65E207BA742F638C24DAB702B1F8 /* Country.swift */,
 				82EA2654F9F8A4EAD22B531FA3B488D9 /* CountryCell.swift */,
@@ -2375,7 +2364,6 @@
 				5E1CFF1C7D6C15457225A6B6F8A0CBE0 /* CountryManager.swift in Sources */,
 				07250E7B8EB9ED86CBF2AA3C6EAAEEE3 /* CountryPickerController.swift in Sources */,
 				668E911D0082893FE8E4E84D9DF6356D /* CountryPickerWithSectionViewController.swift in Sources */,
-				631A9BEA2308450900962232 /* Enums.swift in Sources */,
 				76C43A95B07BA05580BB4D6700F589B0 /* SKCountryPicker-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		5FE4034051CC758FFFDE9593D2E1ECDB /* GY@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 52FB174CF5628B15957E27C66D4A7A64 /* GY@2x.png */; };
 		6012CA2F31E60398C3B65505DB18911D /* UG.png in Resources */ = {isa = PBXBuildFile; fileRef = 30735D53BA3B69E985469DB5F75D43CD /* UG.png */; };
 		62B90EE76F9D6FCC4D820434746EACD5 /* KI@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 48B9189D002CEAE95706764F2FA907ED /* KI@2x.png */; };
+		631A9BEA2308450900962232 /* Enums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631A9BE92308450900962232 /* Enums.swift */; };
 		6343ED6F9516DBECB358FE16B110111B /* CountryPickerController.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 485DCD3FCE4332DD3B4869033850BB16 /* CountryPickerController.bundle */; };
 		64059E67429D1B88DC3DEE3063822B51 /* CZ.png in Resources */ = {isa = PBXBuildFile; fileRef = 816698E10B8863EA0DF3B2ABED1A8615 /* CZ.png */; };
 		64228C345052861ABAE393E9290EEFF4 /* IN.png in Resources */ = {isa = PBXBuildFile; fileRef = D69FD0E7D78D6A2CDD992DCC4B3CF8A3 /* IN.png */; };
@@ -624,7 +625,7 @@
 		2B139C62F06087469E8A1DB1D09FECCB /* GD.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = GD.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/GD.png; sourceTree = "<group>"; };
 		2B8C7D05F2ACD759F2FB8275B527A953 /* SZ@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "SZ@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/SZ@2x.png"; sourceTree = "<group>"; };
 		2C4F160126BD6AE2ECB7F37320080AC2 /* SX@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "SX@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/SX@2x.png"; sourceTree = "<group>"; };
-		2C9F00BD2BE934CCED415EF136250D61 /* SKCountryPicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SKCountryPicker.framework; path = SKCountryPicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C9F00BD2BE934CCED415EF136250D61 /* SKCountryPicker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SKCountryPicker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CE6C39770318BE5AC42EA319A2A2E64 /* Pods-TestCountryPickerFramework-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-TestCountryPickerFramework-umbrella.h"; sourceTree = "<group>"; };
 		2DDCD030E1CA901E1A34A4223B800ECF /* CI@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "CI@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/CI@2x.png"; sourceTree = "<group>"; };
 		2E453D822AA7C7D393F48B81A92F7A78 /* IR@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "IR@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/IR@2x.png"; sourceTree = "<group>"; };
@@ -640,7 +641,7 @@
 		32760D1CF0BE5C2BA41C2969EC62369D /* KG.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = KG.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/KG.png; sourceTree = "<group>"; };
 		32771B1C8E64D8AC29466482AB0EB55A /* PR@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "PR@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/PR@2x.png"; sourceTree = "<group>"; };
 		32887E9278D6A3F809669B891F955B8F /* KR@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "KR@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/KR@2x.png"; sourceTree = "<group>"; };
-		32A42EB17F7A9B711079480B382DA14A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		32A42EB17F7A9B711079480B382DA14A /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		32D6B8A4FA64EC8400038CA3B0C1D475 /* CU.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = CU.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/CU.png; sourceTree = "<group>"; };
 		32DE024D7B9B79E907F12E545B5BFD9D /* IR.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = IR.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/IR.png; sourceTree = "<group>"; };
 		337429BAD7C1A5C07D2BD4C52B55300A /* HT.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = HT.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/HT.png; sourceTree = "<group>"; };
@@ -686,7 +687,7 @@
 		432E213DFD69EC5299008732D0DFD980 /* SN@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "SN@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/SN@2x.png"; sourceTree = "<group>"; };
 		4496A3988A58458C862630141807A532 /* BY.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = BY.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/BY.png; sourceTree = "<group>"; };
 		44BC011B6D94B36F542C9F1D224E1B2C /* TN.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = TN.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/TN.png; sourceTree = "<group>"; };
-		45329A9A26D820D9CF33B22C010226B2 /* Pods_TestCountryPickerFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_TestCountryPickerFramework.framework; path = "Pods-TestCountryPickerFramework.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		45329A9A26D820D9CF33B22C010226B2 /* Pods_TestCountryPickerFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestCountryPickerFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		456F0D1400726F710C793BFFF591C46C /* DE@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "DE@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/DE@2x.png"; sourceTree = "<group>"; };
 		45B27837FDF9BF683DFB62A8A61BF177 /* KH@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "KH@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/KH@2x.png"; sourceTree = "<group>"; };
 		466ABAF861B5AE05196BA9702EA0445F /* IQ@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "IQ@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/IQ@2x.png"; sourceTree = "<group>"; };
@@ -694,7 +695,7 @@
 		47F98C46C05BF4FF632C52ADC46C1197 /* LK.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = LK.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/LK.png; sourceTree = "<group>"; };
 		480F1426216AD3AFF017413B483605FE /* GM.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = GM.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/GM.png; sourceTree = "<group>"; };
 		4835FB53D9C7556774BD61674CF8F4F4 /* CM.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = CM.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/CM.png; sourceTree = "<group>"; };
-		485DCD3FCE4332DD3B4869033850BB16 /* CountryPickerController.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = CountryPickerController.bundle; path = "SKCountryPicker-CountryPickerController.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		485DCD3FCE4332DD3B4869033850BB16 /* CountryPickerController.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CountryPickerController.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		48B9189D002CEAE95706764F2FA907ED /* KI@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "KI@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/KI@2x.png"; sourceTree = "<group>"; };
 		48D1DC1BCDA053C8789C25BBFC757487 /* BZ@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "BZ@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/BZ@2x.png"; sourceTree = "<group>"; };
 		48DB8E75790D359AFAFA00EAA7F46DA0 /* SN.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = SN.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/SN.png; sourceTree = "<group>"; };
@@ -747,6 +748,7 @@
 		62035424BD6BB698AD59E21DF082875C /* CD@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "CD@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/CD@2x.png"; sourceTree = "<group>"; };
 		628DB67DD5A892677E392AB0AB149B81 /* AO.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = AO.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/AO.png; sourceTree = "<group>"; };
 		62C8D67B33AAA6D350FB7D4F2B14039E /* KN.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = KN.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/KN.png; sourceTree = "<group>"; };
+		631A9BE92308450900962232 /* Enums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enums.swift; sourceTree = "<group>"; };
 		64498467524F084AEF00CF649C73EADA /* BA.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = BA.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/BA.png; sourceTree = "<group>"; };
 		645DE9098F037565B92752A07039EE1A /* AI@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "AI@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/AI@2x.png"; sourceTree = "<group>"; };
 		64931DA9060A058A4381BB0F6F82CD44 /* WF.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = WF.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/WF.png; sourceTree = "<group>"; };
@@ -864,7 +866,7 @@
 		9B9BDE22E609905816982150F2D8B8E4 /* MG@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "MG@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/MG@2x.png"; sourceTree = "<group>"; };
 		9CB51B7B42486AABF551E751FE833DE2 /* SY@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "SY@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/SY@2x.png"; sourceTree = "<group>"; };
 		9D915FEF45C317D04A255E423818E128 /* BT@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "BT@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/BT@2x.png"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9E1C5CBA69B49642A386D131DE2BBD5E /* BS@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "BS@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/BS@2x.png"; sourceTree = "<group>"; };
 		9E1F91C24FA29745F1D9D6B6BFCD08F6 /* TO@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "TO@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/TO@2x.png"; sourceTree = "<group>"; };
 		9EC15A636A5DB7AFEABD269920712B58 /* LS.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = LS.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/LS.png; sourceTree = "<group>"; };
@@ -1039,14 +1041,14 @@
 		F078059198FC059C2C6BFC3E1C9EC76B /* PL@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "PL@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/PL@2x.png"; sourceTree = "<group>"; };
 		F0BDC6F351FE968B9CA694971941756E /* NC.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = NC.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/NC.png; sourceTree = "<group>"; };
 		F1C52AEB0B13B902AFAF2E22DA68202E /* MF.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = MF.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/MF.png; sourceTree = "<group>"; };
-		F2835BF566CEE54672FF9B64DA354D64 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		F2835BF566CEE54672FF9B64DA354D64 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		F2A05988B979800DA774B1D547743F5F /* HT@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "HT@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/HT@2x.png"; sourceTree = "<group>"; };
 		F36197DD5323EDCFD3AE1874787423A7 /* KW@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "KW@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/KW@2x.png"; sourceTree = "<group>"; };
 		F3D945E4D4D254DF0314D96040542135 /* LU.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = LU.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/LU.png; sourceTree = "<group>"; };
 		F47AF4938E796DB791BAA70CCB531615 /* MD@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "MD@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/MD@2x.png"; sourceTree = "<group>"; };
 		F5B589C94ED046AF716966E34E651F65 /* GG@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "GG@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/GG@2x.png"; sourceTree = "<group>"; };
 		F640D6689DB218AB4F44E1B108A510A6 /* UZ@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "UZ@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/UZ@2x.png"; sourceTree = "<group>"; };
-		F6FB4DF1A4E13C65DF06F043EDDC04D1 /* SKCountryPicker.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = SKCountryPicker.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		F6FB4DF1A4E13C65DF06F043EDDC04D1 /* SKCountryPicker.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = SKCountryPicker.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F7DDFEB91B73400C224D2B6538D0ABBC /* PW.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = PW.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/PW.png; sourceTree = "<group>"; };
 		F8579D036D16302CB5227EB003ADA86B /* GL.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = GL.png; path = CountryPicker/CountryPicker/CountryPickerController.bundle/GL.png; sourceTree = "<group>"; };
 		FAD750DF16897B15A7B4E6662CB9FF2D /* AM@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = "AM@2x.png"; path = "CountryPicker/CountryPicker/CountryPickerController.bundle/AM@2x.png"; sourceTree = "<group>"; };
@@ -1639,6 +1641,14 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
+		631A9BE62308448200962232 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				631A9BE92308450900962232 /* Enums.swift */,
+			);
+			name = Helper;
+			sourceTree = "<group>";
+		};
 		A0653EA217AF5FA3B39795A22A39C235 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1704,6 +1714,7 @@
 		D32A5D8D77B23CC2ECAD2EE7259AAD22 /* SKCountryPicker */ = {
 			isa = PBXGroup;
 			children = (
+				631A9BE62308448200962232 /* Helper */,
 				269A9A60ABDEFB7BDE22BE864428521C /* Constant.swift */,
 				403F65E207BA742F638C24DAB702B1F8 /* Country.swift */,
 				82EA2654F9F8A4EAD22B531FA3B488D9 /* CountryCell.swift */,
@@ -1803,6 +1814,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
+				TargetAttributes = {
+					AB01CB50105B19A88BAC43637172B832 = {
+						LastSwiftMigration = 1030;
+					};
+				};
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 8.0";
@@ -2359,6 +2375,7 @@
 				5E1CFF1C7D6C15457225A6B6F8A0CBE0 /* CountryManager.swift in Sources */,
 				07250E7B8EB9ED86CBF2AA3C6EAAEEE3 /* CountryPickerController.swift in Sources */,
 				668E911D0082893FE8E4E84D9DF6356D /* CountryPickerWithSectionViewController.swift in Sources */,
+				631A9BEA2308450900962232 /* Enums.swift in Sources */,
 				76C43A95B07BA05580BB4D6700F589B0 /* SKCountryPicker-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2497,6 +2514,7 @@
 			baseConfigurationReference = 2292A63246C7BA4B1464D5D79DDFDAE9 /* Pods-TestCountryPickerFramework.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2520,6 +2538,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2532,6 +2551,7 @@
 			baseConfigurationReference = 073788E2DB12B887287764F879304858 /* Pods-TestCountryPickerFramework.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2555,6 +2575,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2646,8 +2668,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 			};

--- a/Example/TestCountryPickerFramework/Main.storyboard
+++ b/Example/TestCountryPickerFramework/Main.storyboard
@@ -109,13 +109,13 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="lzf-AA-bV2">
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="lzf-AA-bV2">
                                 <rect key="frame" x="112" y="430.66666666666669" width="190" height="35"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fbI-xG-7mA">
-                                        <rect key="frame" x="0.0" y="0.0" width="40" height="35"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fbI-xG-7mA">
+                                        <rect key="frame" x="0.0" y="4.3333333333333144" width="40" height="26"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="35" id="fBb-ow-5P7"/>
+                                            <constraint firstAttribute="height" constant="26" id="fBb-ow-5P7"/>
                                             <constraint firstAttribute="width" constant="40" id="iWP-zK-rUv"/>
                                         </constraints>
                                     </imageView>

--- a/Example/TestCountryPickerFramework/Main.storyboard
+++ b/Example/TestCountryPickerFramework/Main.storyboard
@@ -43,7 +43,6 @@
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Dialing Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="liT-ne-VeH">
                                                                 <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
                                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u08-Yi-RAT">
@@ -58,7 +57,6 @@
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Country Flag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aUa-jb-iph">
                                                                 <rect key="frame" x="0.0" y="0.0" width="286" height="31"/>
                                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn9-ly-arN">
@@ -73,7 +71,6 @@
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show With Section" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="InG-Pr-hQm">
                                                                 <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
                                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XHD-Iz-bdZ">
@@ -100,7 +97,6 @@
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Country Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="02q-c1-uYW">
                                                                 <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
                                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zdd-qz-BG0">
@@ -118,7 +114,6 @@
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Dial Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RfQ-iI-Ria">
                                                                 <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
                                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="25P-lz-fEa">
@@ -158,15 +153,12 @@
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="35" id="i2b-na-rNE"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="18"/>
                                                         <inset key="titleEdgeInsets" minX="20" minY="0.0" maxX="10" maxY="0.0"/>
                                                         <inset key="imageEdgeInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                         <state key="normal" title="+91">
-                                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
-                                                        <connections>
-                                                            <action selector="countryCodeButtonClicked:" destination="O0l-1Z-8PS" eventType="touchUpInside" id="RPx-kA-duD"/>
-                                                        </connections>
                                                     </button>
                                                 </subviews>
                                             </stackView>
@@ -174,11 +166,28 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ply-4I-sqN">
+                                <rect key="frame" x="30" y="794" width="354" height="60"/>
+                                <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="60" id="Vd8-a5-AlQ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="18"/>
+                                <state key="normal" title="Pick Country">
+                                    <color key="titleColor" red="0.96470588239999999" green="0.97254901959999995" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="pickCountryAction:" destination="O0l-1Z-8PS" eventType="touchUpInside" id="c99-X7-aaE"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="vjC-5M-P1O" firstAttribute="bottom" secondItem="Ply-4I-sqN" secondAttribute="bottom" constant="8" id="8TN-wh-BIi"/>
                             <constraint firstItem="4Tj-6H-iZC" firstAttribute="leading" secondItem="vjC-5M-P1O" secondAttribute="leading" constant="30" id="PTM-tj-AxD"/>
+                            <constraint firstItem="Ply-4I-sqN" firstAttribute="leading" secondItem="vjC-5M-P1O" secondAttribute="leading" constant="30" id="Tio-M6-tps"/>
                             <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="4Tj-6H-iZC" secondAttribute="trailing" constant="30" id="b9N-oB-hGD"/>
+                            <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="Ply-4I-sqN" secondAttribute="trailing" constant="30" id="cki-p8-aeH"/>
                             <constraint firstItem="4Tj-6H-iZC" firstAttribute="centerX" secondItem="sxh-pT-lsG" secondAttribute="centerX" id="tAn-li-K9p"/>
                             <constraint firstItem="4Tj-6H-iZC" firstAttribute="top" secondItem="vjC-5M-P1O" secondAttribute="top" constant="50" id="tlN-vr-56X"/>
                         </constraints>
@@ -187,6 +196,7 @@
                     <connections>
                         <outlet property="countryCodeButton" destination="ofv-wr-sb6" id="Qb5-AU-DzT"/>
                         <outlet property="countryImageView" destination="fbI-xG-7mA" id="lZY-6c-ocZ"/>
+                        <outlet property="pickCountryButton" destination="Ply-4I-sqN" id="vMG-tT-Arj"/>
                         <outlet property="showCountryFlagSwitch" destination="Qn9-ly-arN" id="UhV-Ob-vMU"/>
                         <outlet property="showDialingCodeSwitch" destination="u08-Yi-RAT" id="YJK-an-naZ"/>
                         <outlet property="showWithSectionsSwitch" destination="XHD-Iz-bdZ" id="qes-1E-QhZ"/>

--- a/Example/TestCountryPickerFramework/Main.storyboard
+++ b/Example/TestCountryPickerFramework/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="O0l-1Z-8PS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GP5-yV-uQx">
     <device id="retina6_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -10,7 +10,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Demo-->
         <scene sceneID="bSY-ej-0XY">
             <objects>
                 <viewController automaticallyAdjustsScrollViewInsets="NO" id="O0l-1Z-8PS" customClass="ViewController" customModule="TestCountryPickerFramework" customModuleProvider="target" sceneMemberID="viewController">
@@ -19,11 +19,11 @@
                         <viewControllerLayoutGuide type="bottom" id="Zpf-qi-Wtk"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="sxh-pT-lsG">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="4Tj-6H-iZC">
-                                <rect key="frame" x="30" y="94" width="354" height="442"/>
+                                <rect key="frame" x="30" y="25" width="354" height="442"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="CwJ-Vx-WYi">
                                         <rect key="frame" x="0.0" y="0.0" width="354" height="333"/>
@@ -142,7 +142,7 @@
                                                 <rect key="frame" x="0.0" y="44" width="354" height="35"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fbI-xG-7mA">
-                                                        <rect key="frame" x="0.0" y="4.6666666666666856" width="40" height="26"/>
+                                                        <rect key="frame" x="0.0" y="4.6666666666666288" width="40" height="26"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="26" id="fBb-ow-5P7"/>
                                                             <constraint firstAttribute="width" constant="40" id="iWP-zK-rUv"/>
@@ -167,7 +167,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ply-4I-sqN">
-                                <rect key="frame" x="30" y="794" width="354" height="60"/>
+                                <rect key="frame" x="30" y="706" width="354" height="60"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="60" id="Vd8-a5-AlQ"/>
@@ -189,10 +189,11 @@
                             <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="4Tj-6H-iZC" secondAttribute="trailing" constant="30" id="b9N-oB-hGD"/>
                             <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="Ply-4I-sqN" secondAttribute="trailing" constant="30" id="cki-p8-aeH"/>
                             <constraint firstItem="4Tj-6H-iZC" firstAttribute="centerX" secondItem="sxh-pT-lsG" secondAttribute="centerX" id="tAn-li-K9p"/>
-                            <constraint firstItem="4Tj-6H-iZC" firstAttribute="top" secondItem="vjC-5M-P1O" secondAttribute="top" constant="50" id="tlN-vr-56X"/>
+                            <constraint firstItem="4Tj-6H-iZC" firstAttribute="top" secondItem="vjC-5M-P1O" secondAttribute="top" constant="25" id="tlN-vr-56X"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="vjC-5M-P1O"/>
                     </view>
+                    <navigationItem key="navigationItem" title="Demo" id="rUr-We-6YZ"/>
                     <connections>
                         <outlet property="countryCodeButton" destination="ofv-wr-sb6" id="Qb5-AU-DzT"/>
                         <outlet property="countryImageView" destination="fbI-xG-7mA" id="lZY-6c-ocZ"/>
@@ -204,7 +205,27 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pYN-jd-baC" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-149.27536231884059" y="-197.54464285714286"/>
+            <point key="canvasLocation" x="-149" y="-190"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="JS1-Bf-eCt">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jHj-fg-FWJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <navigationController id="GP5-yV-uQx" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" barStyle="black" translucent="NO" id="d65-PR-0pr">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="barTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" red="0.96470588239999999" green="0.97254901959999995" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="O0l-1Z-8PS" kind="relationship" relationship="rootViewController" id="i8w-MC-7aN"/>
+                    </connections>
+                </navigationController>
+            </objects>
+            <point key="canvasLocation" x="-1048" y="-190"/>
         </scene>
     </scenes>
 </document>

--- a/Example/TestCountryPickerFramework/Main.storyboard
+++ b/Example/TestCountryPickerFramework/Main.storyboard
@@ -22,131 +22,165 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="CwJ-Vx-WYi">
-                                <rect key="frame" x="30" y="94" width="354" height="255"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="4Tj-6H-iZC">
+                                <rect key="frame" x="30" y="94" width="354" height="442"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Kuq-zW-YF3">
-                                        <rect key="frame" x="0.0" y="0.0" width="354" height="31"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="CwJ-Vx-WYi">
+                                        <rect key="frame" x="0.0" y="0.0" width="354" height="333"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Dialing Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="liT-ne-VeH">
-                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u08-Yi-RAT">
-                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
-                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </switch>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="O7d-tN-q6O">
+                                                <rect key="frame" x="0.0" y="0.0" width="354" height="177"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Style Controls" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CPu-sp-nKO">
+                                                        <rect key="frame" x="0.0" y="0.0" width="354" height="24"/>
+                                                        <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Kuq-zW-YF3">
+                                                        <rect key="frame" x="0.0" y="44" width="354" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Dialing Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="liT-ne-VeH">
+                                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
+                                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="u08-Yi-RAT">
+                                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
+                                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="CNg-15-mCz">
+                                                        <rect key="frame" x="0.0" y="95" width="354" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Country Flag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aUa-jb-iph">
+                                                                <rect key="frame" x="0.0" y="0.0" width="286" height="31"/>
+                                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn9-ly-arN">
+                                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
+                                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="vbW-sq-Q50">
+                                                        <rect key="frame" x="0.0" y="146" width="354" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show With Section" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="InG-Pr-hQm">
+                                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
+                                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XHD-Iz-bdZ">
+                                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
+                                                                <accessibility key="accessibilityConfiguration" label="show with sections"/>
+                                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="fyq-s3-TL9">
+                                                <rect key="frame" x="0.0" y="207" width="354" height="126"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter Controls" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x5C-2x-hUa">
+                                                        <rect key="frame" x="0.0" y="0.0" width="354" height="24"/>
+                                                        <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aOV-nK-Mzb">
+                                                        <rect key="frame" x="0.0" y="44" width="354" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Country Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="02q-c1-uYW">
+                                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
+                                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zdd-qz-BG0">
+                                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
+                                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <connections>
+                                                                    <action selector="filterByCountryCode:" destination="O0l-1Z-8PS" eventType="valueChanged" id="Mcp-RB-qDE"/>
+                                                                </connections>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hSz-dZ-rbW">
+                                                        <rect key="frame" x="0.0" y="95" width="354" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Dial Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RfQ-iI-Ria">
+                                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
+                                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="15"/>
+                                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="25P-lz-fEa">
+                                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
+                                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <connections>
+                                                                    <action selector="filterByDialCode:" destination="O0l-1Z-8PS" eventType="valueChanged" id="rIp-sM-Ya1"/>
+                                                                </connections>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="CNg-15-mCz">
-                                        <rect key="frame" x="0.0" y="56" width="354" height="31"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ek9-48-QNb">
+                                        <rect key="frame" x="0.0" y="363" width="354" height="79"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show Country Flag" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aUa-jb-iph">
-                                                <rect key="frame" x="0.0" y="0.0" width="286" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country Preview" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mtd-WD-pMP">
+                                                <rect key="frame" x="0.0" y="0.0" width="354" height="24"/>
+                                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="20"/>
+                                                <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qn9-ly-arN">
-                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
-                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </switch>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="vbW-sq-Q50">
-                                        <rect key="frame" x="0.0" y="112" width="354" height="31"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Show With Section" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="InG-Pr-hQm">
-                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XHD-Iz-bdZ">
-                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
-                                                <accessibility key="accessibilityConfiguration" label="show with sections"/>
-                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </switch>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aOV-nK-Mzb">
-                                        <rect key="frame" x="0.0" y="168" width="354" height="31"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Country Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="02q-c1-uYW">
-                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zdd-qz-BG0">
-                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
-                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <connections>
-                                                    <action selector="filterByCountryCode:" destination="O0l-1Z-8PS" eventType="valueChanged" id="Mcp-RB-qDE"/>
-                                                </connections>
-                                            </switch>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hSz-dZ-rbW">
-                                        <rect key="frame" x="0.0" y="224" width="354" height="31"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by Dial Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RfQ-iI-Ria">
-                                                <rect key="frame" x="0.0" y="0.0" width="285" height="31"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="25P-lz-fEa">
-                                                <rect key="frame" x="305" y="0.0" width="51" height="31"/>
-                                                <color key="onTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <connections>
-                                                    <action selector="filterByDialCode:" destination="O0l-1Z-8PS" eventType="valueChanged" id="rIp-sM-Ya1"/>
-                                                </connections>
-                                            </switch>
+                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="lzf-AA-bV2">
+                                                <rect key="frame" x="0.0" y="44" width="354" height="35"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fbI-xG-7mA">
+                                                        <rect key="frame" x="0.0" y="4.6666666666666856" width="40" height="26"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="26" id="fBb-ow-5P7"/>
+                                                            <constraint firstAttribute="width" constant="40" id="iWP-zK-rUv"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFit" contentHorizontalAlignment="left" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ofv-wr-sb6">
+                                                        <rect key="frame" x="40" y="0.0" width="314" height="35"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="35" id="i2b-na-rNE"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <inset key="titleEdgeInsets" minX="20" minY="0.0" maxX="10" maxY="0.0"/>
+                                                        <inset key="imageEdgeInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                        <state key="normal" title="+91">
+                                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="countryCodeButtonClicked:" destination="O0l-1Z-8PS" eventType="touchUpInside" id="RPx-kA-duD"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="lzf-AA-bV2">
-                                <rect key="frame" x="112" y="430.66666666666669" width="190" height="35"/>
-                                <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fbI-xG-7mA">
-                                        <rect key="frame" x="0.0" y="4.3333333333333144" width="40" height="26"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="26" id="fBb-ow-5P7"/>
-                                            <constraint firstAttribute="width" constant="40" id="iWP-zK-rUv"/>
-                                        </constraints>
-                                    </imageView>
-                                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFit" contentHorizontalAlignment="left" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ofv-wr-sb6">
-                                        <rect key="frame" x="40" y="0.0" width="150" height="35"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="150" id="abw-e7-jmE"/>
-                                            <constraint firstAttribute="height" constant="35" id="i2b-na-rNE"/>
-                                        </constraints>
-                                        <inset key="titleEdgeInsets" minX="20" minY="0.0" maxX="10" maxY="0.0"/>
-                                        <inset key="imageEdgeInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        <state key="normal" title="+91">
-                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="countryCodeButtonClicked:" destination="O0l-1Z-8PS" eventType="touchUpInside" id="RPx-kA-duD"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="A3b-eB-zyz"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="CwJ-Vx-WYi" firstAttribute="leading" secondItem="vjC-5M-P1O" secondAttribute="leading" constant="30" id="0Io-Aj-dFT"/>
-                            <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="CwJ-Vx-WYi" secondAttribute="trailing" constant="30" id="1Yq-GB-kvV"/>
-                            <constraint firstItem="lzf-AA-bV2" firstAttribute="centerX" secondItem="sxh-pT-lsG" secondAttribute="centerX" id="MtB-id-xfg"/>
-                            <constraint firstItem="CwJ-Vx-WYi" firstAttribute="top" secondItem="DdQ-N4-djM" secondAttribute="bottom" constant="50" id="Xpy-1D-kxj"/>
-                            <constraint firstItem="lzf-AA-bV2" firstAttribute="centerY" secondItem="sxh-pT-lsG" secondAttribute="centerY" id="w5J-vO-Xgj"/>
+                            <constraint firstItem="4Tj-6H-iZC" firstAttribute="leading" secondItem="vjC-5M-P1O" secondAttribute="leading" constant="30" id="PTM-tj-AxD"/>
+                            <constraint firstItem="vjC-5M-P1O" firstAttribute="trailing" secondItem="4Tj-6H-iZC" secondAttribute="trailing" constant="30" id="b9N-oB-hGD"/>
+                            <constraint firstItem="4Tj-6H-iZC" firstAttribute="centerX" secondItem="sxh-pT-lsG" secondAttribute="centerX" id="tAn-li-K9p"/>
+                            <constraint firstItem="4Tj-6H-iZC" firstAttribute="top" secondItem="vjC-5M-P1O" secondAttribute="top" constant="50" id="tlN-vr-56X"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="vjC-5M-P1O"/>
                     </view>
@@ -160,7 +194,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pYN-jd-baC" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-148" y="-197"/>
+            <point key="canvasLocation" x="-149.27536231884059" y="-197.54464285714286"/>
         </scene>
     </scenes>
 </document>

--- a/Example/TestCountryPickerFramework/Main.storyboard
+++ b/Example/TestCountryPickerFramework/Main.storyboard
@@ -153,7 +153,7 @@
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="35" id="i2b-na-rNE"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" name="HelveticaNeue-Medium" family="Helvetica Neue" pointSize="18"/>
+                                                        <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="18"/>
                                                         <inset key="titleEdgeInsets" minX="20" minY="0.0" maxX="10" maxY="0.0"/>
                                                         <inset key="imageEdgeInsets" minX="10" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                         <state key="normal" title="+91">

--- a/Example/TestCountryPickerFramework/ViewController.swift
+++ b/Example/TestCountryPickerFramework/ViewController.swift
@@ -87,8 +87,6 @@ private extension ViewController {
                 self.countryCodeButton.setTitle(country.dialingCode, for: .normal)
             }
             
-            countryController.detailColor = UIColor.blue
-            countryController.labelColor = UIColor.green
             countryController.isHideFlagImage = !showCountryFlagSwitch.isOn
             countryController.isHideDiallingCode = !showDialingCodeSwitch.isOn
         case false:
@@ -102,8 +100,6 @@ private extension ViewController {
                 self.countryCodeButton.setTitle(country.dialingCode, for: .normal)
             }
             
-            countryController.detailColor = UIColor.blue
-            countryController.labelColor = UIColor.green
             countryController.isHideFlagImage = !showCountryFlagSwitch.isOn
             countryController.isHideDiallingCode = !showDialingCodeSwitch.isOn
         }

--- a/Example/TestCountryPickerFramework/ViewController.swift
+++ b/Example/TestCountryPickerFramework/ViewController.swift
@@ -95,6 +95,7 @@ private extension ViewController {
                 self.countryCodeButton.setTitle(country.dialingCode, for: .normal)
             }
             
+            countryController.flagStyle = .circular
             countryController.isHideFlagImage = !showCountryFlagSwitch.isOn
             countryController.isHideDiallingCode = !showDialingCodeSwitch.isOn
         case false:
@@ -108,6 +109,7 @@ private extension ViewController {
                 self.countryCodeButton.setTitle(country.dialingCode, for: .normal)
             }
             
+            countryController.flagStyle = .corner
             countryController.isHideFlagImage = !showCountryFlagSwitch.isOn
             countryController.isHideDiallingCode = !showDialingCodeSwitch.isOn
         }

--- a/Example/TestCountryPickerFramework/ViewController.swift
+++ b/Example/TestCountryPickerFramework/ViewController.swift
@@ -17,6 +17,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var showDialingCodeSwitch: UISwitch!
     @IBOutlet weak var showWithSectionsSwitch: UISwitch!
     @IBOutlet weak var showCountryFlagSwitch: UISwitch!
+    @IBOutlet weak var pickCountryButton: UIButton!
     
     // MARK: - Func
     override func viewDidLoad() {
@@ -34,6 +35,10 @@ class ViewController: UIViewController {
         countryImageView.image = country.flag
         countryCodeButton.clipsToBounds = true
         countryCodeButton.accessibilityLabel = Accessibility.selectCountryPicker
+        
+        pickCountryButton.layer.cornerRadius = 10
+        pickCountryButton.clipsToBounds = true
+        
     }
     
     private func addAccessibilityLabel() {
@@ -42,10 +47,8 @@ class ViewController: UIViewController {
         showDialingCodeSwitch.accessibilityLabel = "show countries with section"
     }
     
-    @IBAction func countryCodeButtonClicked(_ sender: UIButton) {
-        presentCountryPickerScene(withSelectionControlEnabled: showWithSectionsSwitch.isOn)
-    }
     
+    // MARK: - IBAction Methods
     @IBAction func filterByCountryCode(_ sender: UISwitch) {
         if sender.isOn {
             CountryManager.shared.addFilter(.countryCode)
@@ -62,9 +65,14 @@ class ViewController: UIViewController {
         }
     }
     
+    @IBAction func pickCountryAction(_ sender: UIButton) {
+        presentCountryPickerScene(withSelectionControlEnabled: showWithSectionsSwitch.isOn)
+    }
+    
 }
 
 
+/// MARK: - Private Methods 
 private extension ViewController {
     
     /// Dynamically presents country picker scene with an option of including `Selection Control`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This library is for country picker used in many app for selecting country code o
 
 - [x] Navigate through search and index title of section e.g (in Contact app in iOS)
 - [x] Auto scroll to previous selected country
+- [x] Fitlering country options 
+- [x] Styling view options 
 - [x] Cocoa Pods integrated
 - [x] Best practices followed
 
@@ -87,7 +89,7 @@ class ViewController: UIViewController  {
 ```
 
 ## Filter Options
-There are 3 main filter options `countryName`, `countryCode`, `countryDialCode` and  by country picker default is configured to filter countries based on `countryName`. 
+There are 3 main filter options `countryName`, `countryCode`, `countryDialCode` and  by default country picker has been configured to filter countries based on `countryName`. 
 If you want to add/remove filter options, do as follows: 
 
 ```swift 
@@ -100,6 +102,23 @@ If you want to add/remove filter options, do as follows:
  
  // Removing all filters 
  CountryManager.shared.clearAllFilters() 
+```
+
+## Styling Options
+There are few styling options provided by the library such auto-hiding or styling views.
+```swift 
+
+let countryController = CountryPickerWithSectionViewController.presentController(on: self) { ... } 
+
+// Styling country flag image view 
+countryController.flagStyle = .corner    // E.g .corner, ,circular or .normal 
+
+// Hiding  flag image view 
+countryController.isHideFlagImage = true // False 
+
+// Hiding country dial code 
+countryController.isHideDiallingCode = true  // False
+
 ```
 
 ## Contributing


### PR DESCRIPTION
**Implementation:**
Users will be able to style the looks of the flags in different styles such as `cornered flag`, `circular flag` or `rectangular flag`. Also `country picker` scene and demo project scenes have been re-design to have a look.

**Country Picker with circular flag style** 
<img src="https://user-images.githubusercontent.com/16168370/63213787-17561d80-c143-11e9-9c5c-272c7311c15e.png" width="420" height="400">

**Country Picker with corner flag style**
<img src="https://user-images.githubusercontent.com/16168370/63213788-17eeb400-c143-11e9-9e32-281f4256c865.png" width="420" height="400">

**Country Picker with rectangle flag style**  
<img src="https://user-images.githubusercontent.com/16168370/63213789-17eeb400-c143-11e9-8581-aea7306ff338.png" width="420" height="400">