### PR TITLE
Fix Cyprus country code

### DIFF
--- a/CountryPicker/CountryPicker/Constant.swift
+++ b/CountryPicker/CountryPicker/Constant.swift
@@ -66,7 +66,7 @@ let isoToDigitCountryCodeDictionary: [String: String] = [
     "CR": "506",
     "HR": "385",
     "CU": "53",
-    "CY": "537",
+    "CY": "357",
     "CZ": "420",
     "DK": "45",
     "DJ": "253",


### PR DESCRIPTION
Cyprus country code is 357 not 537