### PR TITLE
Update CountryPickerWithSectionViewController.swift

### DIFF
--- a/CountryPicker/CountryPicker/CountryPickerWithSectionViewController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerWithSectionViewController.swift
@@ -50,9 +50,7 @@ open class CountryPickerWithSectionViewController: CountryPickerController {
         
         let navigationController = UINavigationController(rootViewController: controller)
         
-        if #available(iOS 13.0, *) {
-            
-        } else {
+        if #available(iOS 13.0, *) { } else {
             navigationController.modalPresentationStyle = .overFullScreen
         }
         

--- a/CountryPicker/CountryPicker/CountryPickerWithSectionViewController.swift
+++ b/CountryPicker/CountryPicker/CountryPickerWithSectionViewController.swift
@@ -49,6 +49,13 @@ open class CountryPickerWithSectionViewController: CountryPickerController {
         controller.callBack = handler
         
         let navigationController = UINavigationController(rootViewController: controller)
+        
+        if #available(iOS 13.0, *) {
+            
+        } else {
+            navigationController.modalPresentationStyle = .overFullScreen
+        }
+        
         controller.presentingVC?.present(navigationController, animated: true, completion: nil)
         
         return controller


### PR DESCRIPTION
this code is added to fix a bug that would make the main VC that houses the change country picker, rests it's values and state after choosing a country.
tested devices are iPad mini with iOS 12