### PR TITLE
[FEAT] Reset Last Selected Country

### DIFF
--- a/CountryPicker/CountryPicker/CountryManager.swift
+++ b/CountryPicker/CountryPicker/CountryManager.swift
@@ -69,70 +69,59 @@ open class CountryManager {
     ///
     /// - Note: By default, countries can be filtered by there country names
     internal var filters: Set<CountryFilterOption> = [.countryName]
-    
-    
+        
     private init() {}
+
+}
+
+
+public extension CountryManager {
     
-    func loadCountries() throws {
-        
-        guard let countriesFilePath = countriesFilePath else {
-            throw "Missing contries file path"
-        }
-        
-        let url = URL(fileURLWithPath: countriesFilePath)
-        
-        guard let rawData = try? Data(contentsOf: url),
+    /// Fetch country list from a given property list file path
+    ///
+    /// - Parameter path: URL for the country plist file path
+    /// - Returns: A list of countries sorted by `CountryName`
+    
+    private func fetchCountries(fromURLPath path: URL) throws -> [Country] {
+        guard let rawData = try? Data(contentsOf: path),
             let countryCodes = try? PropertyListSerialization.propertyList(from: rawData, format: nil) as? [String] else {
-                throw "Missing array of countries plist in CountryPicker"
+            throw "[CountryManager] ❌ Missing countries plist file from path: \(path)"
         }
         
-        // Clear old loaded countries
-        countries.removeAll()
-        
-        // Request for fresh copy of sorted country list
+        // Sort country list by `countryName`
         let sortedCountries = countryCodes.map { Country(countryCode: $0) }.sorted { $0.countryName < $1.countryName }
-        countries.append(contentsOf: sortedCountries)
         
+        #if DEBUG
+        print("[CountryManager] ✅ Succefully prepared list of \(sortedCountries.count) countries")
+        #endif
+        
+        return sortedCountries
+    }
+    
+    /// Prepares a country list object for usage while clearing any cached countries
+    ///
+    /// - Throws: Incase country list preperation fails to determine or convert data from a given URL file path.
+    func loadCountries() throws {
+        let url = URL(fileURLWithPath: countriesFilePath ?? "")
+        let fetchedCountries = try fetchCountries(fromURLPath: url)
+        countries.removeAll()
+        countries.append(contentsOf: fetchedCountries)
     }
 
     func allCountries(_ favoriteCountriesLocaleIdentifiers: [String]) -> [Country] {
-          favoriteCountriesLocaleIdentifiers.compactMap {
-            country(withCode: $0) } + countries
+        favoriteCountriesLocaleIdentifiers
+            .compactMap { country(withCode: $0) } + countries
     }
     
+    /// As the function name, resets the last selected country
+    func resetLastSelectedCountry() {
+        lastCountrySelected = nil
+    }
 }
 
 
 // MARK: - Country Filter Methods
 public extension CountryManager {
-    
-    ///  Adds a new filter into `filters` collection with no duplicates
-    ///
-    /// - Parameter filter: New filter to be added
-    
-    func addFilter(_ filter: CountryFilterOption) {
-        filters.insert(filter)
-    }
-    
-    
-    /// Removes a given filter from `filters` collection
-    ///
-    /// - Parameter filter: A filter to b removed
-    
-    func removeFilter(_ filter: CountryFilterOption) {
-        filters = filters.filter { $0 != filter }
-    }
-    
-    
-    /// Removes all stored filters from `filter` collection
-    ///
-    /// - Note: By default, it configures a default filter ~ `CountryFilterOptions.countryName`
-    
-    func clearAllFilters() {
-        filters.removeAll()
-        filters.insert(defaultFilter) // Set default filter option
-    }
-    
     
     /// Requests for a `Country` instance based on country code
     ///
@@ -172,6 +161,38 @@ public extension CountryManager {
             
             return dialCode == countryDialCode
         })
+    }
+}
+
+
+// MARK: - CountryFilterOption Methods
+public extension CountryManager {
+    
+    ///  Adds a new filter into `filters` collection with no duplicates
+    ///
+    /// - Parameter filter: New filter to be added
+    
+    func addFilter(_ filter: CountryFilterOption) {
+        filters.insert(filter)
+    }
+    
+    
+    /// Removes a given filter from `filters` collection
+    ///
+    /// - Parameter filter: A filter to b removed
+    
+    func removeFilter(_ filter: CountryFilterOption) {
+        filters.remove(filter)
+    }
+    
+    
+    /// Removes all stored filters from `filter` collection
+    ///
+    /// - Note: By default, it configures a default filter ~ `CountryFilterOptions.countryName`
+    
+    func clearAllFilters() {
+        filters.removeAll()
+        filters.insert(defaultFilter) // Set default filter option
     }
 }
 

--- a/CountryPicker/CountryPicker/CountryManager.swift
+++ b/CountryPicker/CountryPicker/CountryManager.swift
@@ -82,7 +82,7 @@ public extension CountryManager {
     /// - Parameter path: URL for the country plist file path
     /// - Returns: A list of countries sorted by `CountryName`
     
-    private func fetchCountries(fromURLPath path: URL) throws -> [Country] {
+    func fetchCountries(fromURLPath path: URL) throws -> [Country] {
         guard let rawData = try? Data(contentsOf: path),
             let countryCodes = try? PropertyListSerialization.propertyList(from: rawData, format: nil) as? [String] else {
             throw "[CountryManager] ❌ Missing countries plist file from path: \(path)"

--- a/CountryPicker/CountryPickerTests/CountryManagerTests.swift
+++ b/CountryPicker/CountryPickerTests/CountryManagerTests.swift
@@ -12,6 +12,16 @@ import XCTest
 class CountryPickerTests: XCTestCase {
     var countryManager: CountryManager!
     
+    var validCountryFilePath: String? {
+        let bundle = Bundle(for: CountryManager.self)
+        return bundle.path(forResource: "CountryPickerController.bundle/countries", ofType: "plist")
+    }
+    
+    var invalidCountryFilePath: String? {
+        let bundle = Bundle(for: CountryManager.self)
+        return bundle.path(forResource: "CountryPickerController.bundle/countriess", ofType: "plist")
+    }
+    
     override func setUp() {
         super.setUp()
         countryManager = CountryManager.shared
@@ -23,7 +33,6 @@ class CountryPickerTests: XCTestCase {
     }
     
     func test_afterloadMethod_countriesShoulLoadCorrectly() {
-        
         XCTAssertFalse(countryManager.countries.isEmpty)
         XCTAssert(countryManager.allCountries([]).count != 0, "Cann't load countries")
         XCTAssertEqual(countryManager.defaultFilter, .countryName)
@@ -78,6 +87,36 @@ class CountryPickerTests: XCTestCase {
         XCTAssertEqual(countryManager.country(withName: "India"), country)
         XCTAssertEqual(countryManager.country(withDigitCode: "+91"), country)
         XCTAssertNil(countryManager.country(withDigitCode: "+3232"))
+    }
+    
+    func test_countryLoading_withValidPath() {
+        let urlPath = URL(fileURLWithPath: validCountryFilePath ?? "")
+        let countries = try? countryManager.fetchCountries(fromURLPath: urlPath)
+        XCTAssertNotNil(countries)
+        XCTAssertEqual(countries?.count, 250)
+    }
+    
+    func test_countryLoading_withInvalidPath() {
+        let urlPath = URL(fileURLWithPath: invalidCountryFilePath ?? "")
+        let countries = try? countryManager.fetchCountries(fromURLPath: urlPath)
+        XCTAssertNil(countries)
+        XCTAssertEqual(countries?.count, nil)
+    }
+    
+    func test_lastCountrySelected() {
+        
+        let countrySelected = countryManager.country(withCode: "TZ")
+        countryManager.lastCountrySelected = countrySelected
+        XCTAssertEqual(countryManager.lastCountrySelected?.countryCode, countrySelected?.countryCode)
+    }
+    
+    func test_resetLastCountrySelected() {
+        let countrySelected = countryManager.country(withCode: "TZ")
+        countryManager.lastCountrySelected = countrySelected
+        XCTAssertEqual(countryManager.lastCountrySelected?.countryCode, countrySelected?.countryCode)
+        
+        countryManager.resetLastSelectedCountry()
+        XCTAssertNil(countryManager.lastCountrySelected)
     }
     
     func testPerformanceLoadAndSortCountries() {


### PR DESCRIPTION
**Description:** 
• `fetchCountries(fromURLPath:_)` for fetching countries from a given plist file path
• `loadCountries()` utilises `fetchCountries(fromURLPath:_)` while preparing the country object list
• Exposed `resetLastSelectedCountry()` method to reset previously selected country.