### PR TITLE
Picking the CountryPickerView navigationTitle from the configuration object

### DIFF
--- a/Framework/Framework/Sources/CountryPickerView.swift
+++ b/Framework/Framework/Sources/CountryPickerView.swift
@@ -50,7 +50,7 @@ struct CountryPickerView: View {
                             selectedCountry: $selectedCountry)
             }.listStyle(.grouped)
             .searchable(text: $searchText)
-            .navigationTitle("Country Picker")
+            .navigationTitle(configuration.navigationTitleText)
             .onChange(of: searchText) {
                 filterCountries = manager.filterCountries(searchText: searchText)
             }


### PR DESCRIPTION
The CountryPickerView has a bug where the navigation title is not retrieved from the configuration object. This pull request should fix this