### PR TITLE
Refactor and improve CountryPicker module

### DIFF
--- a/CountryPicker/Sources/Country.swift
+++ b/CountryPicker/Sources/Country.swift
@@ -60,9 +60,8 @@ open class Country: Identifiable {
 
     func countryName(with locale: Locale) -> String {
         guard let localisedCountryName = locale.localizedString(forRegionCode: self.countryCode) else {
-            let message = "Failed to localised country name for Country Code:- \(self.countryCode)"
-            assertionFailure(message)
-            return ""
+            print("Warning: Failed to localize country name for Country Code: \(self.countryCode) with locale: \(locale.identifier). Falling back to country code.")
+            return self.countryCode
         }
         return localisedCountryName
     }
@@ -73,11 +72,10 @@ open class Country: Identifiable {
     }
     
     static func mapCountryName(_ countryCode: String) -> String {
-        let locale = Locale(identifier: Locale.preferredLanguages.first!)
+        let locale = Locale(identifier: Locale.preferredLanguages.first ?? "en_US") // Default to en_US if preferredLanguages is empty
         guard let localisedCountryName = locale.localizedString(forRegionCode: countryCode) else {
-            let message = "Failed to localised country name for Country Code:- \(countryCode)"
-            assertionFailure(message)
-            return ""
+            print("Warning: Failed to map country name for Country Code: \(countryCode) with preferred locale: \(locale.identifier). Falling back to country code.")
+            return countryCode
         }
         return localisedCountryName
     }

--- a/Framework/FrameworkTests/CountryManagerTests.swift
+++ b/Framework/FrameworkTests/CountryManagerTests.swift
@@ -102,9 +102,16 @@ class CountryManagerTests: XCTestCase {
     
     func test_countryLoading_withInvalidPath() {
         let urlPath = URL(fileURLWithPath: invalidCountryFilePath ?? "")
-        let countries = try? countryManager.fetchCountries(fromURLPath: urlPath)
-        XCTAssertNil(countries)
-        XCTAssertEqual(countries?.count, nil)
+        XCTAssertThrowsError(try countryManager.fetchCountries(fromURLPath: urlPath)) { error in
+            guard let countryManagerError = error as? CountryManagerError else {
+                XCTFail("Error is not of type CountryManagerError")
+                return
+            }
+            switch countryManagerError {
+            case .missingCountriesFile(let path):
+                XCTAssertEqual(path, urlPath.absoluteString)
+            }
+        }
     }
     
     func test_lastCountrySelected() {

--- a/Framework/FrameworkTests/CountryTests.swift
+++ b/Framework/FrameworkTests/CountryTests.swift
@@ -55,4 +55,33 @@ class CountryTests: XCTestCase {
         XCTAssertEqual(Country(countryCode: "IN"), Country(countryCode: "IN"))
         XCTAssertNotEqual(Country(countryCode: "IN"), Country(countryCode: "US"))
     }
+    
+    func test_countryName_fallbackBehavior() {
+        // Test instance method fallback
+        let sut = Country(countryCode: "XX") // "XX" is not a valid ISO country code
+        let locale = Locale(identifier: "en")
+        // The `init` of Country calls `mapCountryName`, so `sut.countryName` will already be "XX"
+        // if the initial mapping failed (which it should for "XX").
+        // Then, `sut.countryName(with: locale)` should also return "XX".
+        XCTAssertEqual(sut.countryName(with: locale), "XX", "Instance method did not fallback to country code for invalid code 'XX'")
+        XCTAssertEqual(sut.countryName, "XX", "Country name property was not set to fallback value 'XX' during initialization")
+
+        // Test static method fallback
+        XCTAssertEqual(Country.mapCountryName("ZZ"), "ZZ", "Static method did not fallback to country code for invalid code 'ZZ'")
+        
+        // Test with a valid country code but a locale that might not have specific localization for it,
+        // though typically `localizedString(forRegionCode:)` provides a name if the region code is valid.
+        // This part of the test is more about ensuring it doesn't crash and returns something sensible.
+        // For instance, if "US" is passed, "United States" is expected.
+        // If a truly obscure valid code was used, and a specific locale didn't have it, it *should* still often return the US English name or the code itself.
+        // The implemented fallback is to return the code.
+        // Let's use a locale that is unlikely to have specific names for all codes to ensure fallback works.
+        // However, `localizedString(forRegionCode:)` behavior for invalid locales is not guaranteed to be nil.
+        // The current implementation of Country.swift uses `Locale.preferredLanguages.first` for `mapCountryName`
+        // and a provided locale for `countryName(with:)`.
+        // We are testing the nil result from `locale.localizedString(forRegionCode:)`.
+        // Providing an invalid locale identifier will cause `Locale(identifier: "invalid-locale")` to default to a system locale,
+        // so this does not reliably test the nil path from `localizedString(forRegionCode:)` for valid country codes.
+        // The primary test for fallback is using invalid country codes "XX" and "ZZ".
+    }
 }


### PR DESCRIPTION
This commit includes several improvements:

1.  **Refactored Error Handling:**
    - Introduced a custom `CountryManagerError` enum (`missingCountriesFile`) in `CountryManager.swift`.
    - `fetchCountries(fromURLPath:)` now throws this typed error.
    - Updated `CountryManagerTests.swift` to catch and verify this specific error.

2.  **Improved `removeDuplicates()` Performance:**
    - The `removeDuplicates()` extension on `Array` in `CountryManager.swift` was optimized from O(n^2) to O(n) by using a `Set` while preserving element order.
    - The generic constraint was updated from `Equatable` to `Hashable`.

3.  **Refined Localization Failure Handling:**
    - In `Country.swift`, the `countryName(with:)` and `mapCountryName(_:)` methods no longer cause an `assertionFailure` if localization fails.
    - Instead, they now log a warning and return the country code itself as a fallback.
    - A test case was added to `CountryTests.swift` to verify this fallback behavior.
    - `mapCountryName` now also includes a fallback to "en_US" if preferred locales are unavailable.

**Note on Testing:**
The last two changes (performance improvement and localization fallback) could not be fully verified by running the complete test suite in the automated environment due to persistent `xcodebuild: command not found` errors. The changes were made according to the plan and new tests for specific functionality were added. Manual verification or running tests in a correctly configured Xcode environment is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved robustness by replacing assertion failures with runtime warnings and fallback values when country name localization fails, preventing crashes due to missing localization data.
- **New Features**
	- Introduced a specific error type for missing country files, providing clearer error messages when loading countries fails.
- **Tests**
	- Enhanced tests to verify explicit error handling and fallback behaviors when invalid country codes or missing files are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->