### PR TITLE
Allow selectedCountry to be nullable

### DIFF
--- a/Sources/CountryPicker/CountryPickerView.swift
+++ b/Sources/CountryPicker/CountryPickerView.swift
@@ -23,7 +23,7 @@ struct CountryPickerView: View {
     @State private var filterCountries = [Country]()
     @State private var applySearch = false
     @State private var searchText = ""
-    @Binding private var selectedCountry: Country
+    @Binding private var selectedCountry: Country?
     
     let configuration: Configuration
     let manager: any CountryListDataSource
@@ -35,7 +35,7 @@ struct CountryPickerView: View {
     public
     init(manager: any CountryListDataSource = CountryManager.shared,
          configuration: Configuration = Configuration(),
-         selectedCountry: Binding<Country>) {
+         selectedCountry: Binding<Country?>) {
         self.manager = manager
         self.configuration = configuration
         self._selectedCountry = selectedCountry
@@ -80,8 +80,9 @@ struct CountryPickerView: View {
             }
         }
         .onChange(of: selectedCountry) { newCountry in
+            guard let country = newCountry else { return }
             if configuration.accessibilityConfiguration?.enableVoiceOverAnnouncements == true {
-                let announcement = "Selected \(newCountry.countryName)"
+                let announcement = "Selected \(country.countryName)"
                 UIAccessibility.post(notification: .announcement, argument: announcement)
             }
             presentationMode.wrappedValue.dismiss()
@@ -95,7 +96,7 @@ struct CountryCell: View {
     let isSelected: Bool
     let configuration: Configuration
     
-    @Binding var selectedCountry: Country
+    @Binding var selectedCountry: Country?
     
     var body: some View {
         Button {

--- a/Sources/CountryPicker/CountryPickerWithSectionViewModel.swift
+++ b/Sources/CountryPicker/CountryPickerWithSectionViewModel.swift
@@ -11,14 +11,14 @@ import Combine
 class CountryPickerWithSectionViewModel: ObservableObject {
         
     @Published var sections: [Section] = []
-    @Published var selectedCountry: Country
+    @Published var selectedCountry: Country?
     
     private let dataService: any CountryListDataSource
     private let mapper: SectionMapper
     
     internal init(dataService: any CountryListDataSource = CountryManager.shared,
                   mapper: SectionMapper = SectionMapper(favoriteCountriesLocaleIdentifiers: []),
-                  selectedCountry: Country
+                  selectedCountry: Country?
     ) {
         self.dataService = dataService
         self.mapper = mapper

--- a/Sources/CountryPicker/CountryPickerWithSections.swift
+++ b/Sources/CountryPicker/CountryPickerWithSections.swift
@@ -13,14 +13,14 @@ struct CountryPickerWithSections: View {
 
     @ObservedObject var viewModel: CountryPickerWithSectionViewModel
     @State var searchText: String
-    @Binding private var selectedCountry: Country
+    @Binding private var selectedCountry: Country?
 
     let configuration: Configuration
 
     public init(
          configuration: Configuration = Configuration(),
          searchText: String = "",
-         selectedCountry: Binding<Country>) {
+         selectedCountry: Binding<Country?>) {
          self.configuration = configuration
          _searchText = State(initialValue: searchText)
         _selectedCountry = selectedCountry


### PR DESCRIPTION
While updating the UIKit implementation to SwiftUI, I found out that the `CountryPickerWithSections` doesn't allow for an empty `selectedCountry`. 

In my use-case I don't want a country to be selected when presenting the CountryPicker, which is currently not supported anymore.

This was my previous UIKit implementation:

```Swift
CountryPickerWithSectionViewController.presentController(on: self, configuration: { countryController in
    countryController.configuration.flagStyle = .corner
    countryController.configuration.isCountryFlagHidden = false
    countryController.configuration.isCountryDialHidden = true
  }
) { [weak self] country in
  guard let self = self else { return }
  viewModel.country = CommunityCountry(
    countryName: country.countryName,
    countryCode: country.countryCode,
    countryFlag: country.flag
  )
}
```

I would like to change it to the following:

```
CountryPickerWithSections(
  configuration: Configuration(
    flagStyle: .corner,
    labelFont: TextStyle.subtitle1.font(),
    detailFont: TextStyle.subtitle1.font(),
    isCountryFlagHidden: false,
    isCountryDialHidden: true
  ),
  selectedCountry: selectedCountry // This is now nullable
)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Country selection fields now support having no country selected, allowing for an unselected state.

* **Bug Fixes**
  * Improved handling of country selection to prevent errors when no country is chosen.

* **Accessibility**
  * Enhanced accessibility announcements for country selection to better handle cases where no country is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->