### PR TITLE
Fix: Missing close button in country picker views

### DIFF
--- a/Examples/SPMExample/SPMExample/MainView.swift
+++ b/Examples/SPMExample/SPMExample/MainView.swift
@@ -10,7 +10,7 @@ import CountryPicker
 
 struct MainView: View {
     
-    @State private var selectedCountry: Country = CountryManager.shared.preferredCountry ?? Country(countryCode: "IN")
+    @State private var selectedCountry: Country? = CountryManager.shared.preferredCountry ?? Country(countryCode: "IN")
     
     @State var shouldShowDialingCode: Bool = true
     @State var shouldShowCountryFlag: Bool = true
@@ -68,8 +68,8 @@ struct MainView: View {
                     isCountryPickerPresented.toggle()
                 }) {
                     HStack {
-                        Text(selectedCountry.dialingCode ?? "Select country")
-                        Image(uiImage: selectedCountry.flag ?? .init())
+                        Text(selectedCountry?.dialingCode ?? "Select country")
+                        Image(uiImage: selectedCountry?.flag ?? .init())
                             .resizable()
                             .frame(width: 40, height: 25)
                     }

--- a/Sources/CountryPicker/CountryPickerView.swift
+++ b/Sources/CountryPicker/CountryPickerView.swift
@@ -53,6 +53,18 @@ struct CountryPickerView: View {
             .searchable(text: $searchText)
             .accessibilityLabel("Country list")
             .accessibilityHint("List of countries to choose from")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: {
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        Image(systemName: "xmark")
+                            .font(.callout)
+                            .accessibilityLabel("Close")
+                            .accessibilityHint("Dismiss country picker")
+                    }
+                }
+            }
             .navigationTitle(configuration.navigationTitleText)
             .onChange(of: searchText) { _ in
                 filterCountries = manager.filterCountries(searchText: searchText)
@@ -65,18 +77,6 @@ struct CountryPickerView: View {
             }
             .onDisappear {
                 manager.lastCountrySelected = selectedCountry
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.callout)
-                        .accessibilityLabel("Close")
-                        .accessibilityHint("Dismiss country picker")
-                }
             }
         }
         .onChange(of: selectedCountry) { newCountry in

--- a/Sources/CountryPicker/CountryPickerWithSections.swift
+++ b/Sources/CountryPicker/CountryPickerWithSections.swift
@@ -74,21 +74,21 @@ struct CountryPickerWithSections: View {
                 .searchable(text: $searchText)
                 .accessibilityLabel("Country search")
                 .accessibilityHint("Search for a country by name or code")
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }) {
-                    Image(systemName: "xmark")
-                        .font(.callout)
-                        .accessibilityLabel("Close")
-                        .accessibilityHint("Dismiss country picker")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(action: {
+                            presentationMode.wrappedValue.dismiss()
+                        }) {
+                            Image(systemName: "xmark")
+                                .font(.callout)
+                                .accessibilityLabel("Close")
+                                .accessibilityHint("Dismiss country picker")
+                        }
+                    }
                 }
+                .navigationTitle(configuration.navigationTitleText)
             }
         }
-        .navigationTitle(configuration.navigationTitleText)
     }
 }
 


### PR DESCRIPTION
- The toolbar was positioned outside NavigationStack, causing the close button to not display
- Also fixed type consistency in SPM example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Picker’s Cancel button is now consistently shown within the list, preserving dismissal behavior and accessibility.
  - Improved handling when no country is selected: displays “Select country” and hides the flag, preventing potential errors.
- Refactor
  - Aligned toolbar and navigation title placement for more consistent navigation bar behavior across picker views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->